### PR TITLE
use install instead of CI to avoid npm issues

### DIFF
--- a/meal-ui/Dockerfile
+++ b/meal-ui/Dockerfile
@@ -12,7 +12,7 @@ COPY package.json package-lock.json ./
 
 # install deps
 RUN apk add --no-cache --update python3 make g++ && rm -rf /var/cache/apk/*
-RUN npm ci
+RUN npm install --production
 
 ENV PATH /src/app/node_modules/.bin:$PATH
 


### PR DESCRIPTION
* Invalid: lock file's typescript@5.1.6 does not satisfy typescript@4.9.5
* `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync