### PR TITLE
Smaller DotNet Docker image

### DIFF
--- a/apps/InMeal.Api/Dockerfile
+++ b/apps/InMeal.Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS builder
 
 WORKDIR /build
 
@@ -12,20 +12,10 @@ COPY README.md LICENSE .nxignore package.json package-lock.json tsconfig.base.js
 # dotnet specific files
 COPY Directory.*.* nuget.config .nx-dotnet.rc.json ./
 
-# do you think God stays in heaven because he too lives in fear of what he's created?
-RUN mkdir -p /usr/local/nvm
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v20.11.0
+RUN apk add --no-cache npm nodejs;
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
-
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
-ENV PATH $NODE_PATH:$PATH
-
-RUN npm ci
-# kinda wishing nx-dotnet generated a build script for me here
-RUN npx nx run InMeal.Api:build:production
+# if this fails for some reason, including the node details is helpful
+RUN node --version && npm ci
 RUN npx nx run InMeal.Api:publish
 
 FROM alpine:3.19 as runtime

--- a/apps/InMeal.Api/Dockerfile
+++ b/apps/InMeal.Api/Dockerfile
@@ -28,9 +28,15 @@ RUN npm ci
 RUN npx nx run InMeal.Api:build:production
 RUN npx nx run InMeal.Api:publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM alpine:3.19 as runtime
 
 WORKDIR /release
+
+# https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md#how-to-use-net-core-on-rhel-6--centos-6
+RUN apk update; \
+    apk add --no-cache openssh libunwind nghttp2-libs \
+    libidn krb5-libs libuuid \
+    lttng-ust zlib
 
 COPY --from=builder /build/dist/apps/ .
 
@@ -38,5 +44,7 @@ COPY /apps/InMeal.Core/appsettings.json /apps/InMeal.Api/appsettings.Production.
 
 ENV DOTNET_EnableDiagnostics=0
 ENV ASPNETCORE_ENVIRONMENT='Production'
+# disabled to avoid installing ICU
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
 ENTRYPOINT dotnet InMeal.Api/net7.0/InMeal.Api.dll

--- a/apps/InMeal.Api/Features/Ingredients/IngredientsManager.cs
+++ b/apps/InMeal.Api/Features/Ingredients/IngredientsManager.cs
@@ -25,7 +25,6 @@ public interface IIngredientsManager
     List<MeasurementUnit> GetMeasurementOptions();
 }
 
-[InstanceScopedBusinessService]
 public class IngredientsManager : IIngredientsManager
 {
     private const int DefaultTake = 25;

--- a/apps/InMeal.Api/Features/Recipes/RecipeManager.cs
+++ b/apps/InMeal.Api/Features/Recipes/RecipeManager.cs
@@ -30,7 +30,6 @@ public interface IRecipeManager
     RecipeMetaDto GetMeta();
 }
 
-[InstanceScopedBusinessService]
 public class RecipeManager : IRecipeManager
 {
     private const int DefaultTake = 25;

--- a/apps/InMeal.Api/Features/Upcoming/RecomendedRecipesService.cs
+++ b/apps/InMeal.Api/Features/Upcoming/RecomendedRecipesService.cs
@@ -9,7 +9,6 @@ public interface IRecommendedRecipesService
     Task<List<RecommendedRecipe>> GetRecommended(CancellationToken ct);
 }
 
-[InstanceScopedBusinessService]
 public class RecommendedRecipesService : IRecommendedRecipesService
 {
     private readonly IAsyncRecipeQueryService _queryService;

--- a/apps/InMeal.Api/InMeal.Api.csproj
+++ b/apps/InMeal.Api/InMeal.Api.csproj
@@ -9,6 +9,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <PublishSingleFile>true</PublishSingleFile>
+        <SelfContained>true</SelfContained>
+        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/InMeal.Api/InMeal.Api.csproj
+++ b/apps/InMeal.Api/InMeal.Api.csproj
@@ -11,7 +11,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
-        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <ItemGroup>

--- a/apps/InMeal.Api/InstanceScopedBusinessServiceAttribute.cs
+++ b/apps/InMeal.Api/InstanceScopedBusinessServiceAttribute.cs
@@ -1,7 +1,0 @@
-namespace InMeal.Api;
-
-/// <summary>
-///     Tag a service implementation for registration as an instance scoped service
-/// </summary>
-[AttributeUsage(AttributeTargets.Class)]
-public class InstanceScopedBusinessServiceAttribute : Attribute { }

--- a/apps/InMeal.Api/RegistrationExtensions/ApplicationServiceRegistrationExtensions.cs
+++ b/apps/InMeal.Api/RegistrationExtensions/ApplicationServiceRegistrationExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using Autofac;
-using InMeal.Infrastructure;
+using InMeal.Api.Features.Ingredients;
+using InMeal.Api.Features.Recipes;
+using InMeal.Api.Features.Upcoming;
+using InMeal.Infrastructure.QueryServices;
+using InMeal.Infrastructure.Repositories;
 
 namespace InMeal.Api.RegistrationExtensions;
 
@@ -17,24 +21,35 @@ public static class ApplicationServiceRegistrationExtensions
             .As<ICancellationTokenAccessor>()
             .InstancePerLifetimeScope();
 
-        containerBuilder.RegisterAttributeTaggedServices<InstanceScopedServiceAttribute>();
-        containerBuilder.RegisterAttributeTaggedServices<InstanceScopedBusinessServiceAttribute>();
-
-        return containerBuilder;
+        return containerBuilder
+            .RegisterQueryServices()
+            .RegisterRepositories()
+            .RegisterManagersAndServices();
     }
 
-    /// <summary>
-    ///     Register any services tagged with the instance registration attribute
-    /// </summary>
-    /// <seealso cref="InstanceScopedServiceAttribute" />
-    private static ContainerBuilder RegisterAttributeTaggedServices<T>(this ContainerBuilder containerBuilder)
-        where T : Attribute
+    private static ContainerBuilder RegisterQueryServices(this ContainerBuilder containerBuilder)
     {
-        containerBuilder.RegisterAssemblyTypes(typeof(T).Assembly)
-                        .Where(type => type.GetCustomAttributes(typeof(T), false).Any())
-                        .AsImplementedInterfaces()
-                        .InstancePerLifetimeScope();
-
+        containerBuilder.RegisterType<AsyncRecipeQueryService>().AsImplementedInterfaces().InstancePerDependency();
+        containerBuilder.RegisterType<AsyncRecipeCategoryQueryService>().AsImplementedInterfaces().InstancePerDependency();
+        containerBuilder.RegisterType<AsyncRecipeIngredientQueryService>().AsImplementedInterfaces().InstancePerDependency();
+        
+        return containerBuilder;
+    }
+    
+    private static ContainerBuilder RegisterRepositories(this ContainerBuilder containerBuilder)
+    {
+        containerBuilder.RegisterType<AsyncIngredientRepository>().AsImplementedInterfaces().InstancePerDependency();
+        containerBuilder.RegisterType<AsyncRecipeRepository>().AsImplementedInterfaces().InstancePerDependency();
+        
+        return containerBuilder;
+    }
+    
+    private static ContainerBuilder RegisterManagersAndServices(this ContainerBuilder containerBuilder)
+    {
+        containerBuilder.RegisterType<RecommendedRecipesService>().AsImplementedInterfaces().InstancePerDependency();
+        containerBuilder.RegisterType<RecipeManager>().AsImplementedInterfaces().InstancePerDependency();
+        containerBuilder.RegisterType<IngredientsManager>().AsImplementedInterfaces().InstancePerDependency();
+        
         return containerBuilder;
     }
 }

--- a/apps/InMeal.Api/project.json
+++ b/apps/InMeal.Api/project.json
@@ -35,6 +35,12 @@
             "options": {
                 "selfContained": true,
                 "runtime": "alpine-x64"
+            },
+            "configurations": {
+                "production": {
+                    "verbosity": "quiet",
+                    "configuration": "Release"
+                }
             }
         },
         "serve": {

--- a/apps/InMeal.Api/project.json
+++ b/apps/InMeal.Api/project.json
@@ -31,7 +31,11 @@
         },
         "publish": {
             "executor": "@nx-dotnet/core:publish",
-            "defaultConfiguration": "production"
+            "defaultConfiguration": "production",
+            "options": {
+                "selfContained": true,
+                "runtime": "alpine-x64"
+            }
         },
         "serve": {
             "executor": "@nx-dotnet/core:serve",

--- a/apps/InMeal.Infrastructure/InstanceScopedSericeAttribute.cs
+++ b/apps/InMeal.Infrastructure/InstanceScopedSericeAttribute.cs
@@ -1,7 +1,0 @@
-namespace InMeal.Infrastructure;
-
-/// <summary>
-/// Tag a service implementation for registration as an instance scoped service
-/// </summary>
-[AttributeUsage(AttributeTargets.Class)]
-public class InstanceScopedServiceAttribute : Attribute {}

--- a/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeCategoryQueryService.cs
+++ b/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeCategoryQueryService.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace InMeal.Infrastructure.QueryServices;
 
-[InstanceScopedService]
 public class AsyncRecipeCategoryQueryService : IAsyncRecipeCategoryQueryService
 {
     private readonly IRecipeDbContext _recipeDbContext;

--- a/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeIngredientQueryService.cs
+++ b/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeIngredientQueryService.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace InMeal.Infrastructure.QueryServices;
 
-[InstanceScopedService]
 public class AsyncRecipeIngredientQueryService : IAsyncRecipeIngredientQueryService
 {
     private readonly IRecipeDbContext _recipeDbContext;

--- a/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeQueryService.cs
+++ b/apps/InMeal.Infrastructure/QueryServices/AsyncRecipeQueryService.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace InMeal.Infrastructure.QueryServices;
 
-[InstanceScopedService]
 public class AsyncRecipeQueryService : IAsyncRecipeQueryService
 {
     private readonly IRecipeDbContext _recipeDbContext;

--- a/apps/InMeal.Infrastructure/Repositories/AsyncIngredientRepository.cs
+++ b/apps/InMeal.Infrastructure/Repositories/AsyncIngredientRepository.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace InMeal.Infrastructure.Repositories;
 
-[InstanceScopedService]
 public class AsyncIngredientRepository : IAsyncIngredientRepository
 {
     private readonly IRecipeDbContext _recipeDbContext;

--- a/apps/InMeal.Infrastructure/Repositories/AsyncRecipeRepository.cs
+++ b/apps/InMeal.Infrastructure/Repositories/AsyncRecipeRepository.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging;
 
 namespace InMeal.Infrastructure.Repositories;
 
-[InstanceScopedService]
 public class AsyncRecipeRepository : IAsyncRecipeRepository
 {
     private readonly ILogger<AsyncRecipeRepository> _logger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inmeal-project",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "private": true,
     "scripts": {
         "serve-stack": "npx nx run-many -t serve -p InMeal.Api @inmeal/fui",


### PR DESCRIPTION
From 243MB to 236MB

This could be vastly improved by updating to DotNet 8 (later PR) and building from alpine directly instead of the dotnet-alpine image.

This also removes reflection based registration to improve trimming compatibility. 