### PR TITLE
Improved entire Docker build stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 API_PORT=7078
 SPA_PORT=3002
+MICROSERVICE_PORT=8131
 DATABASE_CONNECTION='Server=my-server.local;Port=3306;Database=InMeal;User=inmeal;Password=supersecretpassword'
 DATABASE_VERSION_MAJOR=1
 DATABASE_VERSION_MINOR=2

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,4 @@
     <MSBuildProjectDirRelativePath>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</MSBuildProjectDirRelativePath>
     <NodeModulesRelativePath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), $(RepoRoot)))</NodeModulesRelativePath>
   </PropertyGroup>
-  <Target Name="CheckNxModuleBoundaries" BeforeTargets="Build">
-    <Exec Command="node $(NodeModulesRelativePath)/node_modules/@nx-dotnet/core/src/tasks/check-module-boundaries.js --project-root &quot;$(MSBuildProjectDirRelativePath)&quot;"/>
-  </Target>
 </Project>

--- a/apps/InMeal.Api/Dockerfile
+++ b/apps/InMeal.Api/Dockerfile
@@ -1,34 +1,32 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publisher
 
 WORKDIR /build
 
-COPY /apps/Configuration ./apps/Configuration
-COPY /apps/InMeal.Api ./apps/InMeal.Api
-COPY /apps/InMeal.Infrastructure ./apps/InMeal.Infrastructure
-COPY /apps/InMeal.Core ./apps/InMeal.Core
+COPY /apps/Configuration ./Configuration
+COPY /apps/InMeal.Api ./InMeal.Api
+COPY /apps/InMeal.Infrastructure ./InMeal.Infrastructure
+COPY /apps/InMeal.Core ./InMeal.Core
+COPY README.md LICENSE Directory.*.* nuget.config ./
 
-# meta and misc.
-COPY README.md LICENSE .nxignore package.json package-lock.json tsconfig.base.json nx.json .eslintrc.json .eslintignore ./
-# dotnet specific files
-COPY Directory.*.* nuget.config .nx-dotnet.rc.json ./
-
-RUN apk add --no-cache npm nodejs;
-
-# if this fails for some reason, including the node details is helpful
-RUN node --version && npm ci
-RUN npx nx run InMeal.Api:publish
+# target the runtime image environment and slim
+# down deployments with a self-contained artifact
+RUN mkdir /publish; \
+    dotnet publish InMeal.Api -o /publish \
+    --self-contained --runtime alpine-x64 --verbosity quiet \
+    --configuration Release \
+    -p:PublishReadyToRun=true
 
 FROM alpine:3.19 as runtime
 
 WORKDIR /release
 
-# https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md#how-to-use-net-core-on-rhel-6--centos-6
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-alpine#dependencies
 RUN apk update; \
     apk add --no-cache openssh libunwind nghttp2-libs \
-    libidn krb5-libs libuuid \
-    lttng-ust zlib
+    libidn krb5-libs libuuid lttng-ust zlib \
+    libgcc libstdc++
 
-COPY --from=builder /build/dist/apps/ .
+COPY --from=publisher /publish .
 
 COPY /apps/InMeal.Core/appsettings.json /apps/InMeal.Api/appsettings.Production.json /apps/InMeal.Api/appsettings.json ./
 
@@ -37,4 +35,5 @@ ENV ASPNETCORE_ENVIRONMENT='Production'
 # disabled to avoid installing ICU
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
-ENTRYPOINT dotnet InMeal.Api/net7.0/InMeal.Api.dll
+# RUN ls -a ./ && ls asda
+ENTRYPOINT ./InMeal.Api

--- a/apps/InMeal.Api/project.json
+++ b/apps/InMeal.Api/project.json
@@ -29,20 +29,6 @@
                 }
             }
         },
-        "publish": {
-            "executor": "@nx-dotnet/core:publish",
-            "defaultConfiguration": "production",
-            "options": {
-                "selfContained": true,
-                "runtime": "alpine-x64"
-            },
-            "configurations": {
-                "production": {
-                    "verbosity": "quiet",
-                    "configuration": "Release"
-                }
-            }
-        },
         "serve": {
             "executor": "@nx-dotnet/core:serve",
             "options": {

--- a/apps/gri/Dockerfile
+++ b/apps/gri/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10-slim-bookworm
 
 WORKDIR /build
 

--- a/apps/gri/Dockerfile
+++ b/apps/gri/Dockerfile
@@ -1,23 +1,49 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.10-slim-bookworm as builder
 
 WORKDIR /build
 
 # the version is pinned for CI
 ENV POETRY_VERSION=1.7.1
+ENV POETRY_NO_INTERACTION=1
+# disable cache for CI
+ENV POETRY_NO_CACHE=1
+# avoid using a venv in a dedicated Python image
+ENV POETRY_VIRTUALENVS_IN_PROJECT=0
+ENV POETRY_VIRTUALENVS_CREATE=0
+ENV POETRY_HOME=/etc/poetry
+ENV PATH="$PATH:/$POETRY_HOME/bin"
+
+RUN mkdir /etc/poetry; \
+    curl -sSL https://install.python-poetry.org | POETRY_HOME=$POETRY_HOME python3 -
 
 RUN pip install -U pip setuptools --no-cache-dir; \
-    pip install --no-cache-dir poetry==$POETRY_VERSION
+    pip install poetry==$POETRY_VERSION --no-cache-dir
 
-COPY ./.python-version ./pyproject.toml ./poetry.lock /
+COPY ./README.md ./LICENSE ./.python-version ./pyproject.toml ./poetry.lock /
 
-# do not install the source in "editable mode"
-# https://python-poetry.org/docs/basic-usage/#installing-dependencies-only
-RUN poetry install --no-root
+# install dependencies before source code to leverage layer caching
+# sync deps to avoid conflicts with the environment
+RUN poetry install --no-dev --no-root --sync --quiet
 
+# copy source code
 COPY ./gri /gri
 
-# copy demo static assets too
-COPY ./static /static
+# assert Poetry installed correctly and pyproject.toml is valid
+RUN poetry --version && poetry check
+
+# don't install the source in "editable mode"
+# https://python-poetry.org/docs/basic-usage/#installing-dependencies-only
+RUN poetry install --no-dev --quiet
+
+RUN poetry build -vV -f sdist
+
+FROM python:3.10-slim-bookworm as runtime
+
+COPY --from=builder /dist/gri-*.tar.gz ./
+# copy the demo content (this can be removed eventually)
+COPY /static /static
+
+RUN pip install ./gri-*.tar.gz
 
 # use "--proxy-headers" to inform uvicorn we're behind a proxy
-CMD ["uvicorn", "gri.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "gri.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8131"]

--- a/apps/gri/LICENSE
+++ b/apps/gri/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Albert Ferguson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/gri/pyproject.toml
+++ b/apps/gri/pyproject.toml
@@ -2,9 +2,9 @@
 name = "gri"
 version = "1.1.0"
 description = "Generative Recipe Images (aka. GRI) - A REST Microservice abstracting the consumption of a generative model for images of a recipe."
-authors = [ "Albert Ferguson" ]
-license = 'Proprietary'
-readme = 'README.md'
+authors = [ "Albert Ferguson <albertferguson118@gmail.com>" ]
+license = "MIT"
+readme = "README.md"
 
 [[tool.poetry.packages]]
 include = "gri"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ networks:
 services:
     inmeal-backend:
         container_name: inmeal-backend
+        image: inmeal/backend
         build:
             dockerfile: ./apps/InMeal.Api/Dockerfile
-        image: inmeal/backend
         restart: unless-stopped
         ports:
             - '${API_PORT}:7078'
@@ -31,12 +31,15 @@ services:
             - '${SPA_PORT}:80'
         depends_on:
             - inmeal-backend
+            - inmeal-generative-recipe-images
         networks:
             - in-meal-network
-    inmeal-gri:
+    inmeal-generative-recipe-images:
         container_name: inmeal-gri
         image: inmeal/gri
         restart: unless-stopped
+        ports:
+            - '${MICROSERVICE_PORT}:8131'
         build:
             context: ./apps/gri
         networks:


### PR DESCRIPTION
- Shrunk the backend/dotnet image from 236MB > 151MB
- Python image now uses `python:3.10-slim-bookworm`. Shrinks image from 1.1GB > 318MB

### Results

```sh
docker images

# output >>>

REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
inmeal/frontend   latest    361708e48cb4   29 seconds ago   12.6MB
inmeal/backend    latest    cfcdb8037d10   2 minutes ago    151MB
inmeal/gri        latest    1ccd37732ad3   6 minutes ago    318MB
```

```sh
docker history inmeal/backend

# output >>>

IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
f2debf8aedb3   3 minutes ago    ENTRYPOINT ["/bin/sh" "-c" "./InMeal.Api"]      0B        buildkit.dockerfile.v0
<missing>      3 minutes ago    ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1     0B        buildkit.dockerfile.v0
<missing>      3 minutes ago    ENV ASPNETCORE_ENVIRONMENT=Production           0B        buildkit.dockerfile.v0
<missing>      3 minutes ago    ENV DOTNET_EnableDiagnostics=0                  0B        buildkit.dockerfile.v0
<missing>      3 minutes ago    COPY /apps/InMeal.Core/appsettings.json /app…   520B      buildkit.dockerfile.v0
<missing>      3 minutes ago    COPY /publish . # buildkit                      129MB     buildkit.dockerfile.v0
<missing>      3 minutes ago    RUN /bin/sh -c apk update;     apk add --no-…   15.2MB    buildkit.dockerfile.v0
<missing>      23 minutes ago   WORKDIR /release                                0B        buildkit.dockerfile.v0
<missing>      6 weeks ago      /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B        
<missing>      6 weeks ago      /bin/sh -c #(nop) ADD file:1f4eb46669b5b6275…   7.38MB  
```

This later command shows the publish step creates a 129MB artefact. This is a ready-to-run self-contained artefact. Versus the ASP DotNet runtime image this seems more than reasonable as an image size (**30% improvement**),

```sh
docker images | grep -E '(mcr.microsoft.com/dotnet/aspnet|inmeal/backend)'

# output >>>

inmeal/backend                    latest    f2debf8aedb3   11 minutes ago   151MB
mcr.microsoft.com/dotnet/aspnet   8.0       c39d0b5b530f   10 days ago      217MB
```

> Forgot to pull the dotnet 7 image, which is larger but can't be stuffed to change it now

Checking out the Python microservice similarly,

```sh
docker history inmeal/gri

# output >>>

IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
1ccd37732ad3   6 minutes ago   CMD ["uvicorn" "gri.main:app" "--proxy-heade…   0B        buildkit.dockerfile.v0
<missing>      6 minutes ago   RUN /bin/sh -c pip install ./gri-*.tar.gz # …   189MB     buildkit.dockerfile.v0
<missing>      6 minutes ago   COPY /static /static # buildkit                 844kB     buildkit.dockerfile.v0
<missing>      9 minutes ago   COPY /dist/gri-*.tar.gz ./ # buildkit           7.86kB    buildkit.dockerfile.v0
<missing>      4 weeks ago     CMD ["python3"]                                 0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     RUN /bin/sh -c set -eux;   savedAptMark="$(a…   12.2MB    buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PYTHON_GET_PIP_SHA256=7cfd4bdc4d475ea971…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PYTHON_GET_PIP_URL=https://github.com/py…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PYTHON_SETUPTOOLS_VERSION=65.5.1            0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PYTHON_PIP_VERSION=23.0.1                   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     RUN /bin/sh -c set -eux;  for src in idle3 p…   32B       buildkit.dockerfile.v0
<missing>      4 weeks ago     RUN /bin/sh -c set -eux;   savedAptMark="$(a…   31.9MB    buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PYTHON_VERSION=3.10.13                      0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV GPG_KEY=A035C8C19219BA821ECEA86B64E628F8…   0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     RUN /bin/sh -c set -eux;  apt-get update;  a…   9.23MB    buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV LANG=C.UTF-8                                0B        buildkit.dockerfile.v0
<missing>      4 weeks ago     ENV PATH=/usr/local/bin:/usr/local/sbin:/usr…   0B        buildkit.dockerfile.v0
<missing>      10 days ago     /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      10 days ago     /bin/sh -c #(nop) ADD file:9deb26e1dbc258df4…   74.8MB    
```

### Related

- #121
- #120
- #118
- #117